### PR TITLE
Convert Avro dates to Ruby dates [MW-314]

### DIFF
--- a/lib/logstash/codecs/avro_schema_registry.rb
+++ b/lib/logstash/codecs/avro_schema_registry.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require "avro"
+require "avro-patches"
 require "open-uri"
 require "schema_registry"
 require "schema_registry/client"

--- a/logstash-codec-avro_schema_registry.gemspec
+++ b/logstash-codec-avro_schema_registry.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency "logstash-codec-line"
   s.add_runtime_dependency "avro"  #(Apache 2.0 license)
+  s.add_runtime_dependency "avro-patches", ">= 0.3"
   s.add_runtime_dependency "schema_registry", ">= 0.1.0" #(MIT license)
   s.add_development_dependency "logstash-devutils"
 end


### PR DESCRIPTION
The avro-patches gem includes a patch that will convert timestamp-millis
and timestamp-micros logical types to Ruby Time objects. We use these
types extensively in our schemas and it simplifies date handling. It will make
it more consistent if we use this format throughout the codebase.