### PR TITLE
Convert Ruby Date to Time objects [MW-314]

### DIFF
--- a/lib/avro_patches/logical_types/decode_date_as_time_patch.rb
+++ b/lib/avro_patches/logical_types/decode_date_as_time_patch.rb
@@ -1,0 +1,14 @@
+# The avro-patches gem will convert some date-related logical-types in
+# Avro schemas to Ruby Date and Time objects.
+#
+# LogStash has methods to convert certain Ruby classes into JSON
+# values, but it does not support Ruby's Date class. It does support
+# Time (which is used by the timestamp-micros and timestamp-millis
+# logical types), so we convert the Date object to Time here.
+Avro::LogicalTypes::IntDate.class_eval do
+  EPOCH_START = Date.new(1970, 1, 1)
+
+  def self.decode(int)
+    (EPOCH_START + int).to_time.utc
+  end
+end

--- a/lib/logstash/codecs/avro_schema_registry.rb
+++ b/lib/logstash/codecs/avro_schema_registry.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require "avro"
 require "avro-patches"
+require "avro_patches/logical_types/decode_date_as_time_patch"
 require "open-uri"
 require "schema_registry"
 require "schema_registry/client"

--- a/logstash-codec-avro_schema_registry.gemspec
+++ b/logstash-codec-avro_schema_registry.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-codec-avro_schema_registry'
-  s.version       = '1.1.0'
+  s.version       = '1.2.0'
   s.licenses      = ['Apache License (2.0)']
   s.summary         = "Encode and decode avro formatted data from a Confluent schema registry"
   s.description     = "Encode and decode avro formatted data from a Confluent schema registry"


### PR DESCRIPTION
The avro-patches gem will deserialize some Avro messages with the
"date" logical-type into Ruby Date objects.

LogStash has methods to convert certain Ruby classes into JSON
values, but it does not support Ruby's Date class. It does support
Time (which is used by the timestamp-micros and timestamp-millis
logical types), so we convert the Date object to Time here.